### PR TITLE
fix: correct path.

### DIFF
--- a/devops/docker/Dockerfile
+++ b/devops/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION=latest
 FROM node:$VERSION AS base
 WORKDIR /app
-COPY package*.json .
+COPY package*.json ./
 RUN npm install
 
 FROM base AS builder
@@ -10,6 +10,5 @@ RUN npm run build
 
 FROM base AS final
 COPY --from=builder /app/dist .
-WORKDIR /app/dist
 EXPOSE 8080
 ENTRYPOINT [ "node", "service" ]


### PR DESCRIPTION
the content of dist was copying over from builder stage to final, and the workdir was app/dist. but there weren't any dist folder (only content were there). So, deleted the /app/dist and using current directory as workdir which is . (/app).